### PR TITLE
Fix. Missing argument in assistant.py in call to audio_helpers.Conver…

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -90,6 +90,7 @@ class Assistant:
             source=self.audio_source,
             sink=self.audio_sink,
             iter_size=self.audio_iter_size,
+            sample_width=self.audio_sample_width
         )
         restart = False
         continue_dialog = True


### PR DESCRIPTION
Fix. Missing argument in `assistant.py` in call to `audio_helpers.ConversationStream`

Thanks to [ipio](https://github.com/ipio) 

Fix for [issue #1](https://github.com/warchildmd/google-assistant-hotword-raspi/issues/1)